### PR TITLE
Add function to rename tabs interactively, useful for mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ Lightweight Vim plugin to enhance the tabline including numbered tab page labels
 ---
 
 ### Features
-Shows the tab page number on every tab label for quickly navigating to the desired tab **`<number>gt`**.  
-Rename the current tab page label.  
-Tabs display an indicator when a buffer has been modified and not saved.  
-Dynamically updates the filename of the currently focused window in the tab page.  
-Eliminates inefficient use of string concatenation operator by using **`printf`** where possible.  
-Does not show filename extensions to preserve the amount of tab label space.  
-Performs runtime calculation of maximum tab label length and truncates accordingly (Dynamic resizing of tab labels).  
-Options are configurable from **`.vimrc`**.  
+Shows the tab page number on every tab label for quickly navigating to the desired tab **`<number>gt`**.
+Rename the current tab page label.
+Tabs display an indicator when a buffer has been modified and not saved.
+Dynamically updates the filename of the currently focused window in the tab page.
+Eliminates inefficient use of string concatenation operator by using **`printf`** where possible.
+Does not show filename extensions to preserve the amount of tab label space.
+Performs runtime calculation of maximum tab label length and truncates accordingly (Dynamic resizing of tab labels).
+Options are configurable from **`.vimrc`**.
 
 ##### Planned Features
-Enhancement of tab label truncation algorithm  
-Toggle tab page numbers on and off by keyboard shortcut  
-Toggle tab label filename extensions on and off by keyboard shortcut  
-Toggle tab label truncation on and off by keyboard shortcut  
-> In progress: keyboard shortcuts and enhancement of tab label truncation algorithm.  
+Enhancement of tab label truncation algorithm
+Toggle tab page numbers on and off by keyboard shortcut
+Toggle tab label filename extensions on and off by keyboard shortcut
+Toggle tab label truncation on and off by keyboard shortcut
+> In progress: keyboard shortcuts and enhancement of tab label truncation algorithm.
 
 ---
 
@@ -144,25 +144,25 @@ This sets the string on the left of the tab label. The default value is shown be
 ```sh
 let tabulousLabelLeftStr = ' '
 ```
- 
+
 ##### Tab Label Right
 This sets the string on the right of the tab label. The default value is shown below.
 ```sh
 let tabulousLabelRightStr = ' '
 ```
- 
+
 ##### Tab Label Number
 This sets the string on the right of the tab label number. The default value is shown below.
 ```sh
 let tabulousLabelNumberStr = ' '
 ```
- 
+
 ##### Tab Label Name Left
 This sets the string on the left of the tab label name. The default value is shown below.
 ```sh
 let tabulousLabelNameLeftStr = ''
 ```
- 
+
 ##### Tab Label Default Name
 This sets the default tab label name. The default value is shown below.
 ```sh
@@ -172,7 +172,14 @@ let tabulousLabelNameDefault = '[No Name]'
 ---
 
 ### Keyboard Shortcuts
-**_TODO_**
+
+There are no default mappings for renaming your tabs, but you can map it easily like this:
+
+```vimL
+map <C-t> :call g:tabulous#renameTab()<cr>
+```
+
+This maps `Ctrl + t` to rename your tab.
 
 ---
 

--- a/doc/tabulous.txt
+++ b/doc/tabulous.txt
@@ -36,7 +36,7 @@ tab page labels and written purely in Vim script.
 FEATURES                                            *tabulous-features*
 
 Shows a tab number on every tab label to quickly navigate to tabs <number>gt.
-Rename the current tab page label.  
+Rename the current tab page label.
 Tabs display an indicator when a buffer has been modified and not saved.
 Dynamically updates the filename of currently focused window in the tab page.
 Eliminates inefficient string concatenation via |printf| where possible.
@@ -115,7 +115,10 @@ added to a new line in your |.vimrc|.
 ==============================================================================
 SHORTCUTS                                           *tabulous-shortcuts*
 
-  *TODO
+  There are no default mappings for renaming your tabs, but you can map it
+  easily like this:
+  `map <C-t> :call g:tabulous#renameTab()<cr>`
+  This maps `Ctrl + t` to rename your tab.
 
 ==============================================================================
 ISSUES                                              *tabulous-issues*

--- a/plugin/tabulous.vim
+++ b/plugin/tabulous.vim
@@ -25,13 +25,13 @@ let g:loadTabulous = 1
 function s:initVariable(var, val) abort
 
   if !exists(a:var)
-    
+
     execute printf("let %s = \'%s\'", a:var, a:val)
 
     return 1
 
   endif
-  
+
   return 0
 
 endfunction
@@ -94,7 +94,7 @@ function s:getTabline() abort
       \g:tabulousCloseStr
     \))
 
-    " divide columns by tab page count for even distribution 
+    " divide columns by tab page count for even distribution
     let tabNameLengthMax = (&columns-usedLength)/(tabPageCount > 0 ? tabPageCount : 1)
 
     " make length a zero or greater number
@@ -190,6 +190,15 @@ function s:removeUserTabLabelName(bufferNum) abort
 
 endfunction
 
+" ask for a name and rename the current tab
+function! g:tabulous#renameTab()
+  call inputsave()
+  let name = input('Enter new name: ')
+  call inputrestore()
+
+  call s:setUserTabLabelName(name)
+endfunction
+
 " command-line :TabulousRename <string> to rename current tab page label as specified
 command! -nargs=1 TabulousRename call <SID>setUserTabLabelName(<q-args>)
 
@@ -202,4 +211,5 @@ augroup Tabulous
 augroup END
 
 call s:setTabline()
+
 


### PR DESCRIPTION
Hey, nice work on this plugin.

I had a [function](https://github.com/lucasprag/vimlociraptor/commit/e5f8eac745ab1e8e1618a7c5ff0dcd261069232a#diff-133ec54d265af3ca9db6babb64616a84R69) to rename my tabs using your command. I think others could have some benefits on it so I created this PR.

It can be used for mappings like in the example I added.

![gif](http://g.recordit.co/4hKBlA0dzL.gif)

[video](http://recordit.co/4hKBlA0dzL)

Thanks