### PR TITLE
Add ability to have a fixed name for tabs regardless of buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ This sets the default tab label name. The default value is shown below.
 let tabulousLabelNameDefault = '[No Name]'
 ```
 
+##### Tab Label Rename Fixed
+The default behaviour is renaming the tab for the current buffer.
+This enables the ability of renaming the tab and use the same name regardless of the current buffer.
+```sh
+let g:tabulousTabLabelRenameFixed = 0
+```
+
 ---
 
 ### Keyboard Shortcuts

--- a/doc/tabulous.txt
+++ b/doc/tabulous.txt
@@ -112,6 +112,11 @@ added to a new line in your |.vimrc|.
   shown below.
   `let tabulousLabelNameDefault = '[No Name]'`
 
+  Tab Label Rename Fixed~
+  The default behaviour is renaming the tab for the current buffer.
+  This enables the ability of renaming the tab and use the same name regardless of the current buffer.
+  `let g:tabulousTabLabelRenameFixed = 0`
+
 ==============================================================================
 SHORTCUTS                                           *tabulous-shortcuts*
 

--- a/plugin/tabulous.vim
+++ b/plugin/tabulous.vim
@@ -20,32 +20,16 @@ endif
 
 let g:loadTabulous = 1
 
-" inspired by similar nerd tree function
-" initialize variables to sane defaults if not set already
-function s:initVariable(var, val) abort
-
-  if !exists(a:var)
-
-    execute printf("let %s = \'%s\'", a:var, a:val)
-
-    return 1
-
-  endif
-
-  return 0
-
-endfunction
-
 " initialize defaults
-call s:initVariable('g:tabulousCloseStr', 'X')
-call s:initVariable('g:tabulousLabelModifiedStr', '+')
-call s:initVariable('g:tabulousLabelLeftStr', ' ')
-call s:initVariable('g:tabulousLabelRightStr', ' ')
-call s:initVariable('g:tabulousLabelNumberStr', ' ')
-call s:initVariable('g:tabulousLabelNameLeftStr', '')
-call s:initVariable('g:tabulousLabelNameOptions', ':t:r')
-call s:initVariable('g:tabulousLabelNameDefault', '[No Name]')
-call s:initVariable('g:tabulousLabelNameTruncate', 1)
+let g:tabulousCloseStr = get(g:, 'tabulousCloseStr', 'X')
+let g:tabulousLabelModifiedStr = get(g:,'tabulousLabelModifiedStr', '+')
+let g:tabulousLabelLeftStr = get(g:,'tabulousLabelLeftStr', ' ')
+let g:tabulousLabelRightStr = get(g:, 'tabulousLabelRightStr', ' ')
+let g:tabulousLabelNumberStr = get(g:,'tabulousLabelNumberStr', ' ')
+let g:tabulousLabelNameLeftStr = get(g:,'tabulousLabelNameLeftStr', '')
+let g:tabulousLabelNameOptions = get(g:,'tabulousLabelNameOptions', ':t:r')
+let g:tabulousLabelNameDefault = get(g:,'tabulousLabelNameDefault', '[No Name]')
+let g:tabulousLabelNameTruncate = get(g:, 'tabulousLabelNameTruncate', 1)
 let s:userTabLabelNameDict = {}
 
 " build tabline and return it

--- a/plugin/tabulous.vim
+++ b/plugin/tabulous.vim
@@ -30,7 +30,7 @@ let g:tabulousLabelNameLeftStr = get(g:,'tabulousLabelNameLeftStr', '')
 let g:tabulousLabelNameOptions = get(g:,'tabulousLabelNameOptions', ':t:r')
 let g:tabulousLabelNameDefault = get(g:,'tabulousLabelNameDefault', '[No Name]')
 let g:tabulousLabelNameTruncate = get(g:, 'tabulousLabelNameTruncate', 1)
-let g:tabulousFixedTabRenamed = get(g:, 'tabulousFixedTabRenamed', 0)
+let g:tabulousTabLabelRenameFixed = get(g:, 'tabulousTabLabelRenameFixed', 0)
 let s:userTabLabelNameDict = {}
 
 " build tabline and return it
@@ -63,7 +63,7 @@ function s:getTabline() abort
     let tabNameStr = (bufferName != '' ? fnamemodify(bufferName, g:tabulousLabelNameOptions) : g:tabulousLabelNameDefault)
 
     " decide if the name if for the tab or for the buffer
-    let nameIndex = g:tabulousFixedTabRenamed ? tabNum : bufferNum
+    let nameIndex = g:tabulousTabLabelRenameFixed ? tabNum : bufferNum
 
     " if user specified a tab label name for this buffer, use it
     let tabNameStr = has_key(s:userTabLabelNameDict, nameIndex) ? s:userTabLabelNameDict[nameIndex] : tabNameStr
@@ -146,7 +146,7 @@ endfunction
 function s:setUserTabLabelName(name) abort
 
   " decide if the name if for the tab or for the buffer
-  let nameIndex = g:tabulousFixedTabRenamed ? tabpagenr() : s:getCurrentBufferNumber(tabpagenr())
+  let nameIndex = g:tabulousTabLabelRenameFixed  ? tabpagenr() : s:getCurrentBufferNumber(tabpagenr())
 
   " store user specified tab label name keyed by the current buffer number
   let s:userTabLabelNameDict[nameIndex] = a:name
@@ -174,7 +174,7 @@ endfunction
 function s:removeUserTabLabelName(bufferNum) abort
 
   " decide if the name if for the tab or for the buffer
-  let nameIndex = g:tabulousFixedTabRenamed ? tabpagenr() : a:bufferNum
+  let nameIndex = g:tabulousTabLabelRenameFixed  ? tabpagenr() : a:bufferNum
 
   if has_key(s:userTabLabelNameDict, nameIndex)
 

--- a/plugin/tabulous.vim
+++ b/plugin/tabulous.vim
@@ -30,6 +30,7 @@ let g:tabulousLabelNameLeftStr = get(g:,'tabulousLabelNameLeftStr', '')
 let g:tabulousLabelNameOptions = get(g:,'tabulousLabelNameOptions', ':t:r')
 let g:tabulousLabelNameDefault = get(g:,'tabulousLabelNameDefault', '[No Name]')
 let g:tabulousLabelNameTruncate = get(g:, 'tabulousLabelNameTruncate', 1)
+let g:tabulousFixedTabRenamed = get(g:, 'tabulousFixedTabRenamed', 0)
 let s:userTabLabelNameDict = {}
 
 " build tabline and return it
@@ -61,8 +62,11 @@ function s:getTabline() abort
     " get the modified tab name or default tab name
     let tabNameStr = (bufferName != '' ? fnamemodify(bufferName, g:tabulousLabelNameOptions) : g:tabulousLabelNameDefault)
 
+    " decide if the name if for the tab or for the buffer
+    let nameIndex = g:tabulousFixedTabRenamed ? tabNum : bufferNum
+
     " if user specified a tab label name for this buffer, use it
-    let tabNameStr = has_key(s:userTabLabelNameDict, bufferNum) ? s:userTabLabelNameDict[bufferNum] : tabNameStr
+    let tabNameStr = has_key(s:userTabLabelNameDict, nameIndex) ? s:userTabLabelNameDict[nameIndex] : tabNameStr
 
     " used to adjust number of available columns
     " based on tab label length and tab count
@@ -141,8 +145,11 @@ endfunction
 
 function s:setUserTabLabelName(name) abort
 
+  " decide if the name if for the tab or for the buffer
+  let nameIndex = g:tabulousFixedTabRenamed ? tabpagenr() : s:getCurrentBufferNumber(tabpagenr())
+
   " store user specified tab label name keyed by the current buffer number
-  let s:userTabLabelNameDict[s:getCurrentBufferNumber(tabpagenr())] = a:name
+  let s:userTabLabelNameDict[nameIndex] = a:name
 
   " set the tabline with the user specified tab label name
   call s:setTabline()
@@ -166,9 +173,12 @@ endfunction
 " remove unused entries from user tab label names
 function s:removeUserTabLabelName(bufferNum) abort
 
-  if has_key(s:userTabLabelNameDict, a:bufferNum)
+  " decide if the name if for the tab or for the buffer
+  let nameIndex = g:tabulousFixedTabRenamed ? tabpagenr() : a:bufferNum
 
-    unlet s:userTabLabelNameDict[a:bufferNum]
+  if has_key(s:userTabLabelNameDict, nameIndex)
+
+    unlet s:userTabLabelNameDict[nameIndex]
 
   endif
 


### PR DESCRIPTION
Hi, great job on this plugin!


The default behaviour is renaming the tab for the current buffer. Steps:

1. Open one buffer and another in a split window
2. Use `:TabulousRename` to rename the tab
3. The tab gets renamed
4. Move your cursor to the other split
5. The tab name uses the current buffer name

[video](https://recordit.co/ie7JHHowKN)
![gif](http://g.recordit.co/ie7JHHowKN.gif)

I added an option ( `let g:tabulousFixedTabRenamed = 1`), disabled by default, but when enabled, it adds the ability of renaming a tab and use the same name regardless of the current buffer

[video](https://recordit.co/O4qWMcMAC4)
![gif](http://g.recordit.co/O4qWMcMAC4.gif)

I hope it can be useful for others as well as it's for me.

Thank you =)